### PR TITLE
edit comment text: stress preview and basic syntax

### DIFF
--- a/template/en/default/bug/comment.html.tmpl
+++ b/template/en/default/bug/comment.html.tmpl
@@ -41,7 +41,8 @@
     <input type="checkbox" name="use_markdown"
            id="use_markdown" value="1" checked="checked"
            onchange="refresh_markdown_preview([% bug.id FILTER none %])">
-    <label id="use_markdown_label" for="use_markdown">Use Markdown for this [% terms.comment %]</label>
-    (<a href="page.cgi?id=markdown.html" target="_blank" title="View Markdown Syntax Guide">help</a>)
+    <label id="use_markdown_label" for="use_markdown">Use basic Markdown for this [% terms.comment %]</label>
+    (please check the <em>Preview</em> and see the
+    <a href="page.cgi?id=markdown.html" target="_blank" title="View Markdown Syntax Guide">syntax guide</a>)
   </div>
 [% END %]


### PR DESCRIPTION
Commenters expect rich Markdown syntax (as available on GitHub or with Pandoc), but Bugzilla only supports some basic markup. For example, code blocks cannot have a language tag and if one is supplied the rendering comes out very bad. Today's example: <https://bugs.r-project.org/show_bug.cgi?id=18874#c0>.

I think we can avoid at least some of the broken submissions if the Markdown checkbox below the comment field says this is "basic" Markdown and mentions the *Preview* feature. This PR suggests one possible wording, but @mmaechler might want to chime in.