### PR TITLE
rebase on release-5.3.3

### DIFF
--- a/Bugzilla/Constants.pm
+++ b/Bugzilla/Constants.pm
@@ -211,7 +211,7 @@ use File::Basename;
 # Bugzilla version
 # NOTE: 5.1.x and 5.3.x are the same lineage, due to 5.2 branching from
 # 5.0.6 instead of 5.1.x
-use constant BUGZILLA_VERSION => "5.3.2+";
+use constant BUGZILLA_VERSION => "5.3.3";
 
 # A base link to the current REST Documentation. We place it here
 # as it will need to be updated to whatever the current release is.

--- a/Bugzilla/Constants.pm
+++ b/Bugzilla/Constants.pm
@@ -209,7 +209,9 @@ use File::Basename;
 # CONSTANTS
 #
 # Bugzilla version
-use constant BUGZILLA_VERSION => "5.1.2+";
+# NOTE: 5.1.x and 5.3.x are the same lineage, due to 5.2 branching from
+# 5.0.6 instead of 5.1.x
+use constant BUGZILLA_VERSION => "5.3.2+";
 
 # A base link to the current REST Documentation. We place it here
 # as it will need to be updated to whatever the current release is.

--- a/Bugzilla/Constants.pm
+++ b/Bugzilla/Constants.pm
@@ -540,7 +540,16 @@ use constant INSTALLATION_MODE_NON_INTERACTIVE => 1;
 use constant DB_MODULE => {
 
   # MySQL 5.0.15 was the first production 5.0.x release.
-  mysql => {db => 'Bugzilla::DB::Mysql', db_version => '5.0.15', name => 'MySQL'},
+  # We blocklist MySQL 8.0 and newer, and explicitly list MariaDB as an
+  # alternative. The db_blklst_str is shown in the auto-generated release notes
+  # instead of the regexp. We can't tell Maria apart from MySQL in our check
+  # and MariaDB skipped versions from 5 to 10, so we'll blocklist 8 and 9 for
+  # MariaDB as well just in case someone configured for 'mariadb' but actually
+  # has MySQL installed. See https://bugzilla.mozilla.org/show_bug.cgi?id=1851354
+  mysql => {db => 'Bugzilla::DB::Mysql', db_version => '5.0.15', name => 'MySQL',
+            db_blocklist => ['^[89]\.'], db_blklst_str => '>= 8.0'},
+  mariadb => {db => 'Bugzilla::DB::Mysql', db_version => '5.1', name => 'MariaDB',
+            db_blocklist => ['^[89]\.']},
   pg =>
     {db => 'Bugzilla::DB::Pg', db_version => '9.00.0000', name => 'PostgreSQL'},
   oracle =>

--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -187,7 +187,13 @@ sub bz_check_server_version {
   $self->disconnect;
 
   my $sql_want = $db->{db_version};
+  my $sql_dontwant = exists $db->{db_blocklist} ? $db->{db_blocklist} : [];
   my $version_ok = vers_cmp($sql_vers, $sql_want) > -1 ? 1 : 0;
+  my $blocklisted;
+  if ($version_ok) {
+    $blocklisted = grep($sql_vers =~ /$_/, @$sql_dontwant);
+    $version_ok = 0 if $blocklisted;
+  }
 
   my $sql_server = $db->{name};
   if ($output) {
@@ -195,12 +201,22 @@ sub bz_check_server_version {
       package => $sql_server,
       wanted  => $sql_want,
       found   => $sql_vers,
-      ok      => $version_ok
+      ok      => $version_ok,
+      blocklisted => $blocklisted
     });
   }
 
   # Check what version of the database server is installed and let
   # the user know if the version is too old to be used with Bugzilla.
+  if ($blocklisted) {
+    die <<EOT;
+
+Your $sql_server v$sql_vers is blocklisted. Please check the
+release notes for details or try a different database engine
+or version.
+
+EOT
+  }
   if (!$version_ok) {
     die <<EOT;
 

--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -630,7 +630,7 @@ use constant ABSTRACT_SCHEMA => {
     FIELDS => [
       id      => {TYPE => 'MEDIUMSERIAL', NOTNULL => 1, PRIMARYKEY => 1},
       type_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         NOTNULL    => 1,
         REFERENCES => {TABLE => 'flagtypes', COLUMN => 'id', DELETE => 'CASCADE'}
       },
@@ -666,7 +666,7 @@ use constant ABSTRACT_SCHEMA => {
   # "flagtypes" defines the types of flags that can be set.
   flagtypes => {
     FIELDS => [
-      id               => {TYPE => 'SMALLSERIAL', NOTNULL => 1, PRIMARYKEY => 1},
+      id               => {TYPE => 'MEDIUMSERIAL', NOTNULL => 1, PRIMARYKEY => 1},
       name             => {TYPE => 'varchar(50)', NOTNULL => 1},
       description      => {TYPE => 'MEDIUMTEXT',  NOTNULL => 1},
       cc_list          => {TYPE => 'varchar(200)'},
@@ -693,7 +693,7 @@ use constant ABSTRACT_SCHEMA => {
   flaginclusions => {
     FIELDS => [
       type_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         NOTNULL    => 1,
         REFERENCES => {TABLE => 'flagtypes', COLUMN => 'id', DELETE => 'CASCADE'}
       },
@@ -715,7 +715,7 @@ use constant ABSTRACT_SCHEMA => {
   flagexclusions => {
     FIELDS => [
       type_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         NOTNULL    => 1,
         REFERENCES => {TABLE => 'flagtypes', COLUMN => 'id', DELETE => 'CASCADE'}
       },

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -475,9 +475,8 @@ sub update_table_definitions {
   $dbh->bz_drop_column('profiles', 'refreshed_when');
   $dbh->bz_drop_column('groups',   'last_changed');
 
-  # 2006-08-06 LpSolit@gmail.com - Bug 347521
-  $dbh->bz_alter_column('flagtypes', 'id',
-    {TYPE => 'SMALLSERIAL', NOTNULL => 1, PRIMARYKEY => 1});
+  # 2019-01-31 dylan@hardison.net - Bug TODO
+  _update_flagtypes_id();
 
   $dbh->bz_alter_column('keyworddefs', 'id',
     {TYPE => 'SMALLSERIAL', NOTNULL => 1, PRIMARYKEY => 1});
@@ -836,6 +835,30 @@ sub _update_product_name_definition {
     $dbh->bz_alter_column('products',   'product', {TYPE => 'varchar(64)'});
     $dbh->bz_alter_column('versions', 'program',
       {TYPE => 'varchar(64)', NOTNULL => 1});
+  }
+}
+
+sub _update_flagtypes_id {
+  my $dbh   = Bugzilla->dbh;
+  my @fixes = (
+    {table => 'flaginclusions', column => 'type_id'},
+    {table => 'flagexclusions', column => 'type_id'},
+    {table => 'flags',          column => 'type_id'},
+  );
+  my $flagtypes_def = $dbh->bz_column_info('flagtypes', 'id');
+  foreach my $fix (@fixes) {
+    my $def = $dbh->bz_column_info($fix->{table}, $fix->{column});
+    if ($def->{TYPE} eq 'INT2') {
+      warn "Dropping $fix->{table}\n";
+      $dbh->bz_drop_related_fks($fix->{table}, $fix->{column});
+      $def->{TYPE} = 'INT3';
+      $dbh->bz_alter_column($fix->{table}, $fix->{column}, $def);
+    }
+  }
+
+  if ($flagtypes_def->{TYPE} eq 'SMALLSERIAL') {
+    $flagtypes_def->{TYPE} = 'MEDIUMSERIAL';
+    $dbh->bz_alter_column('flagtypes', 'id', $flagtypes_def);
   }
 }
 

--- a/Bugzilla/Install/Requirements.pm
+++ b/Bugzilla/Install/Requirements.pm
@@ -296,8 +296,8 @@ sub check_font_file {
 
 sub _checking_for {
   my ($params) = @_;
-  my ($package, $ok, $wanted, $blacklisted, $found)
-    = @$params{qw(package ok wanted blacklisted found)};
+  my ($package, $ok, $wanted, $blocklisted, $found)
+    = @$params{qw(package ok wanted blocklisted found)};
 
   my $ok_string = $ok ? install_string('module_ok') : '';
 
@@ -325,10 +325,10 @@ sub _checking_for {
     $ok_string = install_string('module_not_found');
   }
 
-  my $black_string = $blacklisted ? install_string('blacklisted') : '';
+  my $block_string = $blocklisted ? install_string('blocklisted') : '';
   my $want_string = $wanted ? "$wanted" : install_string('any');
 
-  my $str = sprintf "%s %20s %-11s $ok_string $black_string\n",
+  my $str = sprintf "%s %20s %-11s $ok_string $block_string\n",
     (' ' x $checking_for_indent) . install_string('checking_for'), $package,
     "($want_string)";
   print $ok ? $str : colored($str, COLOR_ERROR);

--- a/Bugzilla/MIME.pm
+++ b/Bugzilla/MIME.pm
@@ -13,7 +13,7 @@ use 5.14.0;
 use parent qw(Email::MIME);
 
 sub new {
-  my ($class, $msg) = @_;
+  my ($class, $msg, $args) = @_;
 
   # Template-Toolkit trims trailing newlines, which is problematic when
   # parsing headers.
@@ -52,7 +52,7 @@ sub new {
   # you're running on. See http://perldoc.perl.org/perlport.html#Newlines
   $msg =~ s/(?:\015+)?\012/\015\012/msg;
 
-  return $class->SUPER::new($msg);
+  return $class->SUPER::new($msg, $args);
 }
 
 sub as_string {
@@ -113,7 +113,7 @@ workarounds.
 =head1 SYNOPSIS
 
   use Bugzilla::MIME;
-  my $email = Bugzilla::MIME->new($message);
+  my $email = Bugzilla::MIME->new($message, $args);
 
 =head1 DESCRIPTION
 

--- a/Bugzilla/Mailer.pm
+++ b/Bugzilla/Mailer.pm
@@ -77,10 +77,10 @@ sub generate_email {
   }
 
   my $email = Bugzilla::MIME->new($msg_header);
-  if (scalar(@parts) == 1) {
-    $email->content_type_set($parts[0]->content_type);
-  }
-  else {
+
+  # If there's only one part, we don't need to set the overall content type
+  # because Email::MIME will automatically take it from that part (bug 1657496)
+  if (scalar(@parts) > 1) {
     $email->content_type_set('multipart/alternative');
 
     # Some mail clients need same encoding for each part, even empty ones.

--- a/Bugzilla/Mailer.pm
+++ b/Bugzilla/Mailer.pm
@@ -21,6 +21,7 @@ use Bugzilla::MIME;
 use Bugzilla::User;
 use Bugzilla::Util;
 
+use Encode qw()
 use Date::Format qw(time2str);
 
 use Email::Sender::Simple qw(sendmail);
@@ -61,6 +62,7 @@ sub generate_email {
       encoding     => 'quoted-printable',
     },
     body_str => $msg_text,
+    encode_check => Encode::FB_DEFAULT
   ));
   if ($templates->{html} && $email_format eq 'html') {
     $template->process($templates->{html}, $vars, \$msg_html)
@@ -73,6 +75,7 @@ sub generate_email {
         encoding     => 'quoted-printable',
       },
       body_str => $msg_html,
+      encode_check => Encode::FB_DEFAULT
       );
   }
 

--- a/Bugzilla/Mailer.pm
+++ b/Bugzilla/Mailer.pm
@@ -21,7 +21,7 @@ use Bugzilla::MIME;
 use Bugzilla::User;
 use Bugzilla::Util;
 
-use Encode qw()
+use Encode qw();
 use Date::Format qw(time2str);
 
 use Email::Sender::Simple qw(sendmail);

--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -136,7 +136,19 @@ sub new {
       $_[0] = $param;
     }
   }
-  return $class->SUPER::new(@_);
+
+  $user = $class->SUPER::new(@_);
+
+  # MySQL considers some non-ascii characters such as umlauts to equal
+  # ascii characters returning a user when it should not.
+  if ($user && ref $param eq 'HASH' && exists $param->{name}) {
+    my $login = $param->{name};
+    if (lc $login ne lc $user->login) {
+      $user = undef;
+    }
+  }
+
+  return $user;
 }
 
 sub super_user {

--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -121,6 +121,9 @@ sub write_text {
   binmode $tmp_fh, ':encoding(utf-8)';
   print $tmp_fh $content;
   close $tmp_fh;
+
+  # File::Temp tries for secure files, but File::Slurp used the umask.
+  chmod(0666 & ~umask, $tmp_filename);
   rename $tmp_filename, $filename;
 }
 

--- a/META.json
+++ b/META.json
@@ -377,7 +377,7 @@
             "Math::Random::ISAAC" : "v1.0.1",
             "Module::Runtime" : "0",
             "Moo" : "2",
-            "Template" : "2.24",
+            "Template" : "3.008",
             "Test::Taint" : "1.06",
             "URI" : "1.55",
             "perl" : "5.014000"

--- a/META.yml
+++ b/META.yml
@@ -186,7 +186,7 @@ requires:
   Math::Random::ISAAC: v1.0.1
   Module::Runtime: '0'
   Moo: '2'
-  Template: '2.24'
+  Template: '3.008'
   Test::Taint: '1.06'
   URI: '1.55'
   perl: '5.014000'

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -69,7 +69,7 @@ my %requires = (
     'Math::Random::ISAAC' => '1.0.1',
     'Moo'                 => 2,
     'Module::Runtime'     => 0,
-    'Template'            => '2.24',
+    'Template'            => '3.008',
     'Test::Taint'         => '1.06',
     'URI'                 => '1.55',
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -62,6 +62,7 @@ my %requires = (
     'Digest::SHA'         => 0,
     'Email::MIME'         => '1.904',
     'Email::Sender'       => '1.300011',
+    'Email::Address'      => 0,
     'HTTP::Request'       => 0,
     'HTTP::Response'      => 0,
     'JSON::XS'            => '2.01',

--- a/app.psgi
+++ b/app.psgi
@@ -90,6 +90,10 @@ my $app = builder {
         mount "/$cgi_name" => $cgi_app{$cgi_name};
     }
 
+    enable 'Redirect', url_patterns => [
+	'/bugzilla/(.*)' => ['/$1', 301 ]
+    ];
+
     # so mount / => $app will make *all* files redirect to the index.
     # instead we use an inline middleware to rewrite / to /index.cgi
     enable sub {

--- a/buglist.cgi
+++ b/buglist.cgi
@@ -143,6 +143,7 @@ foreach my $chart (@charts) {
 sub DiffDate {
   my ($datestr) = @_;
   my $date      = str2time($datestr);
+  return "invalid" if (!$date);
   my $age       = time() - $date;
 
   if ($age < 18 * 60 * 60) {

--- a/chart.cgi
+++ b/chart.cgi
@@ -318,14 +318,10 @@ sub plot {
 
   my $format
     = $template->get_format("reports/chart", "", scalar($cgi->param('ctype')));
-  $format->{'ctype'} = 'text/html' if $cgi->param('debug');
 
   $cgi->set_dated_content_disp('inline', 'chart', $format->{extension});
   print $cgi->header($format->{'ctype'});
   disable_utf8() if ($format->{'ctype'} =~ /^image\//);
-
-  # Debugging PNGs is a pain; we need to be able to see the error messages
-  $vars->{'chart'}->dump() if $cgi->param('debug');
 
   $template->process($format->{'template'}, $vars)
     || ThrowTemplateError($template->error());
@@ -361,10 +357,6 @@ sub view {
   $vars->{'category'} = Bugzilla::Chart::getVisibleSeries();
 
   print $cgi->header();
-
-  # If we have having problems with bad data, we can set debug=1 to dump
-  # the data structure.
-  $chart->dump() if $cgi->param('debug');
 
   $template->process("reports/create-chart.html.tmpl", $vars)
     || ThrowTemplateError($template->error());

--- a/docs/en/rst/installing/essential-post-install-config.rst
+++ b/docs/en/rst/installing/essential-post-install-config.rst
@@ -90,7 +90,7 @@ This section corresponds to choosing a :param:`mail_delivery_method` of
 :paramval:`Sendmail`.
 
 Unless you know what you are doing, and can deal with the possible problems
-of spam, bounces and blacklists, it is probably unwise to set up your own
+of spam, bounces and blocklists, it is probably unwise to set up your own
 mail server just for Bugzilla. However, if you wish to do so, some guidance
 follows.
 

--- a/report.cgi
+++ b/report.cgi
@@ -312,13 +312,6 @@ $vars->{'height'}          = $height;
 $vars->{'queries'}         = $extra_data;
 $vars->{'saved_report_id'} = $cgi->param('saved_report_id');
 
-if ( $cgi->param('debug')
-  && Bugzilla->params->{debug_group}
-  && Bugzilla->user->in_group(Bugzilla->params->{debug_group}))
-{
-  $vars->{'debug'} = 1;
-}
-
 if ($action eq "wrap") {
 
   # So which template are we using? If action is "wrap", we will be using
@@ -367,23 +360,8 @@ else {
 my $format = $template->get_format("reports/report", $formatparam,
   scalar($cgi->param('ctype')));
 
-# If we get a template or CGI error, it comes out as HTML, which isn't valid
-# PNG data, and the browser just displays a "corrupt PNG" message. So, you can
-# set debug=1 to always get an HTML content-type, and view the error.
-$format->{'ctype'} = "text/html" if $cgi->param('debug');
-
 $cgi->set_dated_content_disp("inline", "report", $format->{extension});
 print $cgi->header($format->{'ctype'});
-
-# Problems with this CGI are often due to malformed data. Setting debug=1
-# prints out both data structures.
-if ($cgi->param('debug')) {
-  require Data::Dumper;
-  say "<pre>data hash:";
-  say html_quote(Data::Dumper::Dumper(%data));
-  say "\ndata array:";
-  say html_quote(Data::Dumper::Dumper(@image_data)) . "\n\n</pre>";
-}
 
 # All formats point to the same section of the documentation.
 $vars->{'doc_section'} = 'using/reports-and-charts.html#reports';

--- a/t/004template.t
+++ b/t/004template.t
@@ -123,10 +123,10 @@ foreach my $include_path (@include_paths) {
 
     # Forbid single quotes to delimit URLs, see bug 926085.
     if ($data =~ /href=\\?'/) {
-      ok(0, "$path contains blacklisted constructs: href='...'");
+      ok(0, "$path contains blocklisted constructs: href='...'");
     }
     else {
-      ok(1, "$path contains no blacklisted constructs");
+      ok(1, "$path contains no blocklisted constructs");
     }
 
     # Forbid cgi.param(). cgi_param() must be used instead.

--- a/template/en/default/bug/create/user-message.html.tmpl
+++ b/template/en/default/bug/create/user-message.html.tmpl
@@ -15,7 +15,9 @@
   # the 'product' variable.
   #%]
 
-Before reporting [% terms.abug %], please read the 
+<font color=#800000>This is a place to report bugs in R itself only, <font color=#d00000><b>this is NOT the place to report issues with contributed packages</b></font> - please use <tt>maintainer('package-name')</tt> in R for the correct contact.<br>Do NOT abuse the bug reporting system for questions, please use the mailing lists instead!</font>
+<p>
+Before reporting [% terms.abug %], <b><u>please make sure you read the <a target=_new  href="http://r.research.att.com/man/R-FAQ.html#R-Bugs">R Bugs section in R FAQ</a></u></b> and
 <a href="page.cgi?id=bug-writing.html">
 [% terms.bug %] writing guidelines</a>, please look at the list of
 <a href="duplicates.cgi">most frequently reported [% terms.bugs %]</a>, and please

--- a/template/en/default/config.js.tmpl
+++ b/template/en/default/config.js.tmpl
@@ -64,7 +64,7 @@ var [% cf.name FILTER js %] = [ [% FOREACH x = cf.legal_values %]'[% x.name FILT
 // =======================
 //
 // It is not necessary to list all products and components here.
-// Instead, you can define a "blacklist" for some commonly used words
+// Instead, you can define a "blocklist" for some commonly used words
 // or word fragments that occur in a product or component name
 // but should _not_ trigger product/component search.
 
@@ -84,7 +84,7 @@ var target_milestone = new Object();
 // Product and Component Exceptions
 // ================================
 //
-// A blacklist for some commonly used words or word fragments 
+// A blocklist for some commonly used words or word fragments
 // that occur in a product or component name but should *not*
 // trigger product/component search in QuickSearch.
 

--- a/template/en/default/index.html.tmpl
+++ b/template/en/default/index.html.tmpl
@@ -11,9 +11,9 @@
   #%]
 
 [% PROCESS global/header.html.tmpl
-   title = "$terms.Bugzilla Main Page"
+   title = "R bug tracking system - Main Page"
    header = "Main Page" 
-   header_addl_info = "version $constants.BUGZILLA_VERSION"
+#  header_addl_info = "version $constants.BUGZILLA_VERSION"
 %]
 
 [% IF release %]
@@ -62,7 +62,7 @@
 [% END %]
 
 <div id="page-index">
-  <h1 id="welcome"> Welcome to [% terms.Bugzilla %]</h1>
+  <h1 id="welcome"> Welcome to the R bug tracking system</h1>
   <div class="intro">[% Hook.process('intro') %]</div>
 
   <div class="bz_common_actions">
@@ -86,6 +86,14 @@
       <li>
         <a id="help" href="[% docs_urlbase FILTER html %]using/index.html"><span>Documentation</span></a>
       </li>
+    </ul>
+  </div>
+
+  <div>
+    <ul>
+      <li><a href="enter_bug.cgi">Enter a new [% terms.bug %] report</a><br>&nbsp;</li>
+      <li><a href="buglist.cgi?query_format=advanced&short_desc_type=allwordssubstr&short_desc=&long_desc_type=substring&long_desc=&bug_file_loc_type=allwordssubstr&bug_file_loc=&deadlinefrom=&deadlineto=&bug_status=NEW&bug_status=ASSIGNED&bug_status=CONFIRMED&bug_status=REOPENED&bug_status=UNCONFIRMED&emailassigned_to1=1&emailtype1=substring&email1=&emailassigned_to2=1&emailreporter2=1&emailcc2=1&emailtype2=substring&email2=&bugidtype=include&bug_id=&votes=&chfieldfrom=&chfieldto=Now&chfieldvalue=&cmdtype=doit&order=bugs.delta_ts%20desc&field0-0-0=noop&type0-0-0=noop&value0-0-0=">Show open bugs new-to-old</a><br>&nbsp;</li>
+      <li><a href="query.cgi">Search existing [% terms.bug %] reports</a></li>
     </ul>
   </div>
 

--- a/template/en/default/setup/strings.txt.pl
+++ b/template/en/default/setup/strings.txt.pl
@@ -32,7 +32,7 @@ END
 The file ##file## must point to a TrueType or OpenType font file
 (its extension must be .ttf or .otf).
 END
-  blacklisted                 => '(blacklisted)',
+  blocklisted                 => '(blocklisted)',
   bz_schema_exists_before_220 => <<'END',
 You are upgrading from a version before 2.20, but the bz_schema table
 already exists. This means that you restored a mysqldump into the Bugzilla


### PR DESCRIPTION
As a minimal update, it seems we should rebase our instance on `release-5.3.3` (renumbered from the 5.1 branch, [mostly abandoned](https://www.bugzilla.org/blog/2024/09/03/release-of-bugzilla-5.2-5.0.4.1-and-4.4.14/#:~:text=5.3.3)), which means merging [11 commits](https://github.com/s-u/bugzilla/compare/Rbugs-master...bugzilla:bugzilla:release-5.3.3) from their (old) master branch. I tried the rebase long ago locally just to see what changes it entails but didn't send a PR, presumably because I cannot really test it myself. I'm sending this PR now for your inspiration, hoping that it helps.

Please note the change in the DB Schema ("increase the size of the flagtype id column"), also blocking MySQL >= 8.0, and in the mailer ("noncharacters in comments cause bugmail sending to fail").